### PR TITLE
fix: set is_accelerate_false when accelerate is not available

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -17,7 +17,7 @@ try:
     from accelerate.utils import set_module_tensor_to_device
     is_accelerate_available = True
 except:
-    pass
+    is_accelerate_available = False
 
 class DownloadAndLoadDepthAnythingV2Model:
     @classmethod


### PR DESCRIPTION
Fixes the following ComfyUI error when accelerate is not installed.

```
Error occurred when executing DownloadAndLoadDepthAnythingV2Model:

name 'is_accelerate_available' is not defined
```